### PR TITLE
Import Route component from global build

### DIFF
--- a/src/Route.js
+++ b/src/Route.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react'
-import Route from 'react-router/Route'
+import {Route} from 'react-router'
 import type {Match, Location, RouterHistory} from 'react-router'
 
 const isEmptyChildren = children => React.Children.count(children) === 0


### PR DESCRIPTION
As of React Router 5.0.0, the package does not allow one to import components directly. Instead, it suggests to import from the global namespace and have tree shaking do its work.